### PR TITLE
add gcloud manual deployment

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/app.yaml
+++ b/app.yaml
@@ -7,8 +7,12 @@ handlers:
 - url: /
   static_files: build/index.html
   upload: build/index.html
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /(.*)
   static_files: build/\1
   upload: build/(.*)
+  secure: always
+  redirect_http_response_code: 301
 # [END handlers]

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,14 @@
+# [START runtime]
+runtime: nodejs8
+# [END runtime]
+
+# [START handlers]
+handlers:
+- url: /
+  static_files: build/index.html
+  upload: build/index.html
+
+- url: /(.*)
+  static_files: build/\1
+  upload: build/(.*)
+# [END handlers]

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,0 +1,3 @@
+dispatch:
+- url: "api.bacontraveller.tk/*"
+  service: api

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
     "semantic-ui-react": "^0.82.5"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "serve -s build",
+    "prestart": "npm install -g serve",
+    "local": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy": "gcloud app deploy --version=v1"
   },
   "browserslist": {
     "development": [


### PR DESCRIPTION
Deploys client to https://bacontraveller.tk/ 
(Also, not in this PR but deployed server to https://api.bacontraveller.tk/)

Google app engine uses `package.json`'s start command when deploying. So I changed `start` to build and serve the static assets instead.
**The implication is that now to develop locally, run `yarn local` instead of `yarn start`.**
Note that for now, only I can run deploy as you don't have credentials for gcloud cli to access the BaconTraveller project.
Automatic deployment not included, to be set up if necessary